### PR TITLE
fix(deferreddeeplink): pass error object

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -227,7 +227,7 @@ public class FacebookLogin: CAPPlugin {
     @objc func getDeferredDeepLink(_ call: CAPPluginCall) {
         AppLinkUtility.fetchDeferredAppLink { url, error in
             if let error = error {
-                call.reject("Error retrieving deferred deep link", nil, error.localizedDescription)
+                call.reject("Error retrieving deferred deep link", nil, error)
                 return
             }
 


### PR DESCRIPTION
## Summary
- pass error object to `call.reject` for deferred deep link failures

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run lint` *(fails: 19 problems (19 errors, 0 warnings))*
- `npm run swiftlint` *(warn: Not running SwiftLint for non-macOS platform: linux)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f954d4d48328bdb069dae69b621d