### PR TITLE
chore(ios): update facebook sdk to 18.0.1

### DIFF
--- a/CapacitorCommunityFacebookLogin.podspec
+++ b/CapacitorCommunityFacebookLogin.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.swift_version = '5.1'
   s.static_framework = true
   s.dependency 'Capacitor'
-  s.dependency 'FBSDKCoreKit', '17.0.0'
-  s.dependency 'FBSDKLoginKit', '17.0.0'
+  s.dependency 'FBSDKCoreKit', '18.0.1'
+  s.dependency 'FBSDKLoginKit', '18.0.1'
 end

--- a/demo/angular/ios/App/Podfile.lock
+++ b/demo/angular/ios/App/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - Capacitor (6.0.0-rc.2):
     - CapacitorCordova
-  - CapacitorCommunityFacebookLogin (6.0.0):
+  - CapacitorCommunityFacebookLogin (7.0.0):
     - Capacitor
-    - FBSDKCoreKit (= 17.0.0)
-    - FBSDKLoginKit (= 17.0.0)
+    - FBSDKCoreKit (= 18.0.1)
+    - FBSDKLoginKit (= 18.0.1)
   - CapacitorCordova (6.0.0-rc.2)
-  - FBAEMKit (17.0.0):
-    - FBSDKCoreKit_Basics (= 17.0.0)
-  - FBSDKCoreKit (17.0.0):
-    - FBAEMKit (= 17.0.0)
-    - FBSDKCoreKit_Basics (= 17.0.0)
-  - FBSDKCoreKit_Basics (17.0.0)
-  - FBSDKLoginKit (17.0.0):
-    - FBSDKCoreKit (= 17.0.0)
+  - FBAEMKit (18.0.1):
+    - FBSDKCoreKit_Basics (= 18.0.1)
+  - FBSDKCoreKit (18.0.1):
+    - FBAEMKit (= 18.0.1)
+    - FBSDKCoreKit_Basics (= 18.0.1)
+  - FBSDKCoreKit_Basics (18.0.1)
+  - FBSDKLoginKit (18.0.1):
+    - FBSDKCoreKit (= 18.0.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -37,13 +37,13 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Capacitor: 616838064c270088c3c51e0bb2f57259c09f3d55
-  CapacitorCommunityFacebookLogin: f725f1240b8f7ab300723a668591cb8301341cc4
+  CapacitorCommunityFacebookLogin: a697a6800d2827f2155d59e443764ce295dde4e9
   CapacitorCordova: 62056f853503fb402c3bd9ea9b93b30f23d1c1ce
-  FBAEMKit: 31a20c2d8744d8c57d3a5b7ae4e27b4fdd819193
-  FBSDKCoreKit: dac911b656816f8d0b06e5fa4bac60e89505bb3b
-  FBSDKCoreKit_Basics: 92b7b7458d57091370b0b6cc197578874c3b4b16
-  FBSDKLoginKit: 5d5271ebfd1e39c6b071de8db5c4bd6255be3561
+  FBAEMKit: 78fb38f212fa49029aff24c669a39648d9b4e68b
+  FBSDKCoreKit: 7f96852f2539bdb88ba8d47e5ab4ae70a6f8d691
+  FBSDKCoreKit_Basics: 78fb38f212fa49029aff24c669a39648d9b4e68b
+  FBSDKLoginKit: 78fb38f212fa49029aff24c669a39648d9b4e68b
 
 PODFILE CHECKSUM: 5a3e712f80ddbdc883b5d7499fca4a61050361b8
 
-COCOAPODS: 1.13.0
+COCOAPODS: 1.16.2

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,8 +5,8 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'FBSDKCoreKit', '17.0.0'
-  pod 'FBSDKLoginKit', '17.0.0'
+  pod 'FBSDKCoreKit', '18.0.1'
+  pod 'FBSDKLoginKit', '18.0.1'
 end
 
 target 'Plugin' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,20 +2,20 @@ PODS:
   - Capacitor (5.0.0):
     - CapacitorCordova
   - CapacitorCordova (5.0.0)
-  - FBAEMKit (16.1.3):
-    - FBSDKCoreKit_Basics (= 16.1.3)
-  - FBSDKCoreKit (16.1.3):
-    - FBAEMKit (= 16.1.3)
-    - FBSDKCoreKit_Basics (= 16.1.3)
-  - FBSDKCoreKit_Basics (16.1.3)
-  - FBSDKLoginKit (16.1.3):
-    - FBSDKCoreKit (= 16.1.3)
+  - FBAEMKit (18.0.1):
+    - FBSDKCoreKit_Basics (= 18.0.1)
+  - FBSDKCoreKit (18.0.1):
+    - FBAEMKit (= 18.0.1)
+    - FBSDKCoreKit_Basics (= 18.0.1)
+  - FBSDKCoreKit_Basics (18.0.1)
+  - FBSDKLoginKit (18.0.1):
+    - FBSDKCoreKit (= 18.0.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
-  - FBSDKCoreKit (= 16.1.3)
-  - FBSDKLoginKit (= 16.1.3)
+  - FBSDKCoreKit (= 18.0.1)
+  - FBSDKLoginKit (= 18.0.1)
 
 SPEC REPOS:
   trunk:
@@ -33,11 +33,11 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: b332cb737d447561e854039fb72195206685dce2
   CapacitorCordova: 4ea17670ee562680988a7ce9db68dee5160fe564
-  FBAEMKit: af2972f39bb0f3f7c45998f435b007833c32ffb2
-  FBSDKCoreKit: 19e2e18b3be578d7a51fed8fdd8c152bef0b9511
-  FBSDKCoreKit_Basics: dd9826ce3c9fd9f8cdf8dbbd0ef0a53e6c0c9e7e
-  FBSDKLoginKit: c395c63a1a6cf4a8a1e6103fd94b8c46329ee81c
+  FBAEMKit: 78fb38f212fa49029aff24c669a39648d9b4e68b
+  FBSDKCoreKit: 7f96852f2539bdb88ba8d47e5ab4ae70a6f8d691
+  FBSDKCoreKit_Basics: 78fb38f212fa49029aff24c669a39648d9b4e68b
+  FBSDKLoginKit: 78fb38f212fa49029aff24c669a39648d9b4e68b
 
-PODFILE CHECKSUM: 84bd0ef43d21cc257916d7be16544e4f2fe7d24d
+PODFILE CHECKSUM: a68315cfab9be0f791777bbf3c7b396c6cdb661a
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.16.2


### PR DESCRIPTION
## Summary
- bump FBSDKCoreKit and FBSDKLoginKit dependencies to 18.0.1 in the podspec and iOS Podfile
- refresh the plugin and Angular demo Podfile.lock files with the new Facebook SDK versions, checksums, and CocoaPods metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d120b90d248328a7c0c682e957ff6c