### PR TITLE
Guard deferred deep link fetch when Facebook config is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,10 @@ setAdvertiserIDCollectionEnabled(options: { enabled: boolean; }) => Promise<void
 getDeferredDeepLink() => Promise<{ uri: string | undefined; }>
 ```
 
+> **Note:** On iOS the promise is rejected if either `FacebookAppID` or `FacebookClientToken`
+> are missing from your app's `Info.plist`. Make sure to configure the Facebook SDK before
+> calling this method.
+
 **Returns:** <code>Promise&lt;{ uri: string; }&gt;</code>
 
 --------------------

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -225,6 +225,16 @@ public class FacebookLogin: CAPPlugin {
     }
 
     @objc func getDeferredDeepLink(_ call: CAPPluginCall) {
+        guard let appId = Bundle.main.object(forInfoDictionaryKey: "FacebookAppID") as? String, !appId.isEmpty else {
+            call.reject("Missing FacebookAppID in Info.plist. Configure Facebook SDK before calling getDeferredDeepLink().")
+            return
+        }
+
+        guard let clientToken = Bundle.main.object(forInfoDictionaryKey: "FacebookClientToken") as? String, !clientToken.isEmpty else {
+            call.reject("Missing FacebookClientToken in Info.plist. Configure Facebook SDK before calling getDeferredDeepLink().")
+            return
+        }
+
         AppLinkUtility.fetchDeferredAppLink { url, error in
             if let error = error {
                 call.reject("Error retrieving deferred deep link", nil, error)


### PR DESCRIPTION
## Summary
- guard the iOS deferred deep link fetch and reject immediately when FacebookAppID or FacebookClientToken are not configured
- document the Info.plist requirement for getDeferredDeepLink in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac7c460f08328a86c8b8f70bb9d7a